### PR TITLE
.travis.yaml: notifications to upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,3 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-
-notifications:
-  email:
-    - nodejs-build-notifications+travis@googlegroups.com


### PR DESCRIPTION
This disables sending travis notifications to upstream.